### PR TITLE
Backend/filtration migration

### DIFF
--- a/app/Console/Commands/MqttListen.php
+++ b/app/Console/Commands/MqttListen.php
@@ -234,6 +234,18 @@ class MqttListen extends Command
             return;
         }
 
+        // Parse valve/2 ack (drain valve): when ack=1, update state and publish so frontend stays in sync
+        if (preg_match('#^mfc_fallback/([^/]+)/valve/2/ack$#', $topic, $matches)) {
+            $serial = $matches[1];
+            if ($value !== 1) {
+                $this->warn("⚠ Valve 2 (drain) ack=0 for device {$serial} (command did not execute, skipping)");
+                return;
+            }
+            $this->info("✓ Valve 2 (drain) ack received for device {$serial}");
+            $this->filtrationService->handleValve2Ack($serial);
+            return;
+        }
+
         // Parse valve/2 state (drain valve)
         if (preg_match('#^mfc_fallback/([^/]+)/valve/2/state$#', $topic, $matches)) {
             $serial = $matches[1];

--- a/app/Console/Commands/MqttListen.php
+++ b/app/Console/Commands/MqttListen.php
@@ -2,7 +2,9 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Device;
 use App\Services\MQTTSensorDataHandlerService;
+use App\Services\FiltrationService;
 use Illuminate\Console\Command;
 use PhpMqtt\Client\MqttClient;
 use PhpMqtt\Client\ConnectionSettings;
@@ -11,14 +13,16 @@ use Illuminate\Support\Facades\Log;
 class MqttListen extends Command
 {
     protected $signature = 'mqtt:listen {--device-id=1 : Device ID to associate with readings}';
-    protected $description = 'Listen to MQTT sensor topics continuously';
+    protected $description = 'Listen to MQTT sensor topics continuously (runs forever until process is stopped; auto-reconnects on disconnect)';
 
     protected $sensorHandler;
+    protected $filtrationService;
 
-    public function __construct(MQTTSensorDataHandlerService $sensorHandler)
+    public function __construct(MQTTSensorDataHandlerService $sensorHandler, FiltrationService $filtrationService)
     {
         parent::__construct();
         $this->sensorHandler = $sensorHandler;
+        $this->filtrationService = $filtrationService;
     }
 
     public function handle()
@@ -30,60 +34,110 @@ class MqttListen extends Command
         $connectionName = config('mqtt-client.default_connection');
         $config = config("mqtt-client.connections.$connectionName");
 
-        $clientId = $config['client_id'] ?? 'laravel_' . uniqid();
+        // Keep-alive: 120 seconds to reduce "No ping response in time" on slow/unstable networks
+        $keepAlive = (int) env('MQTT_KEEP_ALIVE_INTERVAL', 120);
 
-        $client = new MqttClient(
-            $config['host'],
-            $config['port'],
-            $clientId,
-            MqttClient::MQTT_3_1
-        );
+        // Persistent session: broker keeps subscriptions and delivers messages that arrived while offline
+        $usePersistentSession = filter_var(env('MQTT_USE_PERSISTENT_SESSION', true), FILTER_VALIDATE_BOOLEAN);
 
         $settings = (new ConnectionSettings())
             ->setUsername(env('MQTT_USERNAME', 'Biotech'))
             ->setPassword(env('MQTT_PASSWORD', ''))
             ->setUseTls(true)
             ->setTlsSelfSignedAllowed(true)
-            ->setKeepAliveInterval(60)
+            ->setKeepAliveInterval($keepAlive)
             ->setLastWillTopic('device/status')
             ->setLastWillMessage('disconnected')
             ->setLastWillQualityOfService(1);
 
-        try {
-            $client->connect($settings, true);
-            $this->info("✓ Connected to MQTT broker");
+        $reconnectDelay = (int) env('MQTT_RECONNECT_DELAY_SECONDS', 10);
 
-            // Subscribe to sensor topics
-            $topics = [
-                "hydronew/ai-classification/backend",
-            ];
+        // Unique suffix per user/device: hydronew_backend_{serial} or hydronew_backend_user_{id} or hydronew_backend_device_{id}
+        $clientIdSuffix = $this->resolveClientIdSuffix($deviceId);
 
-            foreach ($topics as $topic) {
-                $client->subscribe($topic, function ($topic, $message) use ($deviceId) {
-                    $this->handleMessage($topic, $message, $deviceId);
-                }, 1); // QoS level 1 - at least once delivery
-                
-                $this->info("✓ Subscribed to: {$topic}");
-            }
+        // Run forever: each reconnection uses a NEW client instance so subscriptions and message loop work correctly
+        while (true) {
+            $client = null;
+            try {
+                // Persistent session requires stable client ID so broker can restore subscriptions and deliver queued messages
+                $baseId = $config['client_id'] ?? 'laravel_mqtt_hydronew';
+                $clientId = $usePersistentSession
+                    ? ($baseId . '_' . $clientIdSuffix)
+                    : ($baseId . '_' . $clientIdSuffix . '_' . uniqid());
+                $client = new MqttClient(
+                    $config['host'],
+                    $config['port'],
+                    $clientId,
+                    MqttClient::MQTT_3_1
+                );
 
-            $this->info("Listening for sensor data... (Press Ctrl+C to stop)");
-            $this->newLine();
+                // cleanSession=false: broker keeps subscriptions and delivers offline messages on reconnect
+                $useCleanSession = !$usePersistentSession;
+                $client->connect($settings, $useCleanSession);
+                $this->info("✓ Connected to MQTT broker (keep-alive: {$keepAlive}s, client: {$clientId}, persistent: " . ($usePersistentSession ? 'yes' : 'no') . ")");
 
-            // Keep the connection alive and process messages
-            $client->loop(true, true);
+                // Brief delay so broker connection is fully ready before we send subscriptions
+                usleep(500000); // 0.5 second
 
-        } catch (\Exception $e) {
-            $this->error("MQTT Error: " . $e->getMessage());
-            Log::error("MQTT Connection Error", [
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString()
-            ]);
-            
-            return Command::FAILURE;
-        } finally {
-            if (isset($client)) {
-                $client->disconnect();
-                $this->info("Disconnected from MQTT broker");
+                // Subscribe to sensor topics and filtration topics
+                $topics = [
+                    "hydronew/ai-classification/backend",
+                    // Filtration topics with wildcards
+                    "mfc/+/pump/3/ack",
+                    "mfc/+/pump/3/state",
+                    "mfc/+/valve/1/ack",
+                    "mfc/+/valve/1/state",
+                    "mfc_fallback/+/valve/2/ack",
+                    "mfc_fallback/+/valve/2/state",
+                    "reservoir_fallback/+/pump/1/ack",
+                    "reservoir_fallback/+/pump/1/state",
+                ];
+
+                foreach ($topics as $topic) {
+                    $client->subscribe($topic, function ($topic, $message) use ($deviceId) {
+                        $this->handleMessage($topic, $message, $deviceId);
+                    }, 1); // QoS level 1 - at least once delivery
+                    
+                    $this->info("✓ Subscribed to: {$topic}");
+                }
+
+                $this->info("Listening for sensor data... (Press Ctrl+C to stop)");
+                $this->newLine();
+
+                // Run loop until connection dies (exitWhenQueuesEmpty=false so we don't exit before SUBACKs are processed)
+                $client->loop(true, false);
+
+            } catch (\Exception $e) {
+                $this->error("MQTT Error: " . $e->getMessage());
+                Log::error("MQTT Connection Error", [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString()
+                ]);
+
+                // Safely disconnect if still connected (avoids throw in finally)
+                if (isset($client) && $client->isConnected()) {
+                    try {
+                        $client->disconnect();
+                    } catch (\Throwable $discEx) {
+                        Log::warning("MQTT disconnect after error", ['error' => $discEx->getMessage()]);
+                    }
+                }
+
+                $this->warn("Reconnecting in {$reconnectDelay} seconds...");
+                sleep($reconnectDelay);
+                continue;
+            } finally {
+                // Safely disconnect (never throw from finally - client may already be dead)
+                if (isset($client)) {
+                    try {
+                        if ($client->isConnected()) {
+                            $client->disconnect();
+                            $this->info("Disconnected from MQTT broker");
+                        }
+                    } catch (\Throwable $e) {
+                        Log::debug("MQTT disconnect in finally", ['error' => $e->getMessage()]);
+                    }
+                }
             }
         }
 
@@ -95,23 +149,12 @@ class MqttListen extends Command
         try {
             $this->line("[{$topic}] Received: " . substr($message, 0, 200) . "...");
 
-            // Decode JSON payload
-            $data = json_decode($message, true);
-
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                $this->warn("⚠ Invalid JSON: " . json_last_error_msg());
-                Log::warning("Invalid MQTT JSON payload", [
-                    'topic' => $topic,
-                    'message' => $message,
-                    'error' => json_last_error_msg()
-                ]);
-                return;
+            // Route to appropriate handler based on topic
+            if ($topic === 'hydronew/ai-classification/backend') {
+                $this->handleAIClassificationTopic($message);
+            } else {
+                $this->handleFiltrationTopic($topic, $message);
             }
-
-            // Check if this is AI classification topic
-                $this->sensorHandler->handleAIClassificationPayload($data);
-                $this->info("✓ Processed AI classification data");
-
 
             $this->newLine();
 
@@ -124,5 +167,117 @@ class MqttListen extends Command
                 'trace' => $e->getTraceAsString()
             ]);
         }
+    }
+
+    protected function handleAIClassificationTopic(string $message): void
+    {
+        // Decode JSON payload
+        $data = json_decode($message, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->warn("⚠ Invalid JSON: " . json_last_error_msg());
+            Log::warning("Invalid MQTT JSON payload", [
+                'message' => $message,
+                'error' => json_last_error_msg()
+            ]);
+            return;
+        }
+
+        $this->sensorHandler->handleAIClassificationPayload($data);
+        $this->info("✓ Processed AI classification data");
+    }
+
+    protected function handleFiltrationTopic(string $topic, string $message): void
+    {
+        // Parse message as integer (ack/state values are always integers: 1 or 0)
+        $value = (int)trim($message);
+
+        // Topic patterns:
+        // mfc/{serial}/pump/3/ack
+        // mfc/{serial}/pump/3/state
+        // mfc/{serial}/valve/1/ack
+        // mfc/{serial}/valve/1/state
+        // mfc_fallback/{serial}/valve/2/ack
+        // mfc_fallback/{serial}/valve/2/state
+        // reservoir_fallback/{serial}/pump/1/ack
+        // reservoir_fallback/{serial}/pump/1/state
+
+        // Parse pump/3 ack: only process when ack=1 (command executed). ack=0 means did not execute.
+        if (preg_match('#^mfc/([^/]+)/pump/3/ack$#', $topic, $matches)) {
+            $serial = $matches[1];
+            if ($value !== 1) {
+                $this->warn("⚠ Pump 3 ack=0 for device {$serial} (command did not execute, skipping)");
+                return;
+            }
+            $this->info("✓ Pump 3 ack received for device {$serial}");
+            $this->filtrationService->handlePump3Ack($serial);
+            return;
+        }
+
+        // Parse valve/1 ack: when ack=1, update state and publish so frontend stays in sync (in case IoT didn't send state)
+        if (preg_match('#^mfc/([^/]+)/valve/1/ack$#', $topic, $matches)) {
+            $serial = $matches[1];
+            if ($value !== 1) {
+                $this->warn("⚠ Valve 1 ack=0 for device {$serial} (command did not execute, skipping)");
+                return;
+            }
+            $this->info("✓ Valve 1 ack received for device {$serial}");
+            $this->filtrationService->handleValve1Ack($serial);
+            return;
+        }
+
+        // Parse valve/1 state (we track state changes from IoT)
+        if (preg_match('#^mfc/([^/]+)/valve/1/state$#', $topic, $matches)) {
+            $serial = $matches[1];
+            $this->info("✓ Valve 1 state={$value} for device {$serial}");
+            $this->filtrationService->handleValve1State($serial, $value);
+            return;
+        }
+
+        // Parse valve/2 state (drain valve)
+        if (preg_match('#^mfc_fallback/([^/]+)/valve/2/state$#', $topic, $matches)) {
+            $serial = $matches[1];
+            $this->info("✓ Valve 2 (drain) state={$value} for device {$serial}");
+            $this->filtrationService->handleValve2State($serial, $value);
+            return;
+        }
+
+        // Parse restart pump/1 ack: only process when ack=1 (command executed). ack=0 means did not execute.
+        if (preg_match('#^reservoir_fallback/([^/]+)/pump/1/ack$#', $topic, $matches)) {
+            $serial = $matches[1];
+            if ($value !== 1) {
+                $this->warn("⚠ Restart pump ack=0 for device {$serial} (command did not execute, skipping)");
+                return;
+            }
+            $this->info("✓ Restart pump ack received for device {$serial}");
+            $this->filtrationService->handleRestartPumpAck($serial);
+            return;
+        }
+
+        // Log unhandled filtration topics for debugging
+        Log::debug("MqttListen: Unhandled filtration topic", [
+            'topic' => $topic,
+            'message' => $message
+        ]);
+    }
+
+    /**
+     * Resolve a unique suffix for the MQTT client ID: user ID of the user connected to this device.
+     * Format: "user_{id}". Fallback "device_{id}" if no user is linked.
+     */
+    protected function resolveClientIdSuffix(int $deviceId): string
+    {
+        $device = Device::find($deviceId);
+
+        if (!$device) {
+            return 'device_' . $deviceId;
+        }
+
+        $firstUser = $device->users()->first();
+        if ($firstUser) {
+            return 'user_' . $firstUser->id;
+        }
+
+        return 'device_' . $deviceId;
     }
 }

--- a/app/Http/Controllers/Filtration/FiltrationCommandController.php
+++ b/app/Http/Controllers/Filtration/FiltrationCommandController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Http\Controllers\Filtration;
+
+use App\Http\Controllers\Controller;
+use App\Models\Device;
+use App\Services\FiltrationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class FiltrationCommandController extends Controller
+{
+    public function __construct(
+        protected FiltrationService $filtrationService
+    ) {
+    }
+
+    /**
+     * Resolve the device for the authenticated user.
+     * If request has 'serial', use that device (must belong to user). Otherwise use user's first device.
+     */
+    protected function resolveDevice(Request $request): ?Device
+    {
+        $user = $request->user();
+        $serial = $request->input('serial');
+
+        if ($serial) {
+            return $user->devices()->where('serial_number', $serial)->first();
+        }
+
+        return $user->devices()->first();
+    }
+
+    /**
+     * Start Process – publish OPEN to mfc/{serial}/pump/3.
+     * Backend will publish state when ack=1 is received.
+     */
+    public function startProcess(Request $request): JsonResponse
+    {
+        $device = $this->resolveDevice($request);
+        if (!$device) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No device found. Pair a device first or provide a valid serial.',
+            ], 404);
+        }
+
+        $this->filtrationService->publishStartProcessCommand($device->serial_number);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Start process command sent. State will update when device acknowledges.',
+        ], 200);
+    }
+
+    /**
+     * Open Valve 1 – publish OPEN to mfc/{serial}/valve/1.
+     */
+    public function openValve1(Request $request): JsonResponse
+    {
+        $device = $this->resolveDevice($request);
+        if (!$device) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No device found. Pair a device first or provide a valid serial.',
+            ], 404);
+        }
+
+        $this->filtrationService->publishOpenValve1Command($device->serial_number);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Open valve 1 command sent. State will update when device acknowledges.',
+        ], 200);
+    }
+
+    /**
+     * Close Valve 1 – publish CLOSE to mfc/{serial}/valve/1.
+     */
+    public function closeValve1(Request $request): JsonResponse
+    {
+        $device = $this->resolveDevice($request);
+        if (!$device) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No device found. Pair a device first or provide a valid serial.',
+            ], 404);
+        }
+
+        $this->filtrationService->publishCloseValve1Command($device->serial_number);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Close valve 1 command sent. State will update when device acknowledges.',
+        ], 200);
+    }
+
+    /**
+     * Open Drain Valve – publish OPEN to mfc_fallback/{serial}/valve/2.
+     */
+    public function openDrainValve(Request $request): JsonResponse
+    {
+        $device = $this->resolveDevice($request);
+        if (!$device) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No device found. Pair a device first or provide a valid serial.',
+            ], 404);
+        }
+
+        $this->filtrationService->publishOpenDrainValveCommand($device->serial_number);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Open drain valve command sent. State will update when device acknowledges.',
+        ], 200);
+    }
+
+    /**
+     * Close Drain Valve – publish CLOSE to mfc_fallback/{serial}/valve/2.
+     */
+    public function closeDrainValve(Request $request): JsonResponse
+    {
+        $device = $this->resolveDevice($request);
+        if (!$device) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No device found. Pair a device first or provide a valid serial.',
+            ], 404);
+        }
+
+        $this->filtrationService->publishCloseDrainValveCommand($device->serial_number);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Close drain valve command sent. State will update when device acknowledges.',
+        ], 200);
+    }
+
+    /**
+     * Restart – publish OPEN to reservoir_fallback/{serial}/pump/1.
+     * Shown after restart notification; backend publishes stage states when ack=1 is received.
+     */
+    public function restart(Request $request): JsonResponse
+    {
+        $device = $this->resolveDevice($request);
+        if (!$device) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No device found. Pair a device first or provide a valid serial.',
+            ], 404);
+        }
+
+        $this->filtrationService->publishRestartCommand($device->serial_number);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Restart command sent. Stage states will update when device acknowledges.',
+        ], 200);
+    }
+}

--- a/app/Jobs/ProcessFiltrationStageJob.php
+++ b/app/Jobs/ProcessFiltrationStageJob.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\FiltrationProcess;
+use App\Services\FiltrationService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class ProcessFiltrationStageJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $filtrationProcessId;
+    public string $action;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(int $filtrationProcessId, string $action)
+    {
+        $this->filtrationProcessId = $filtrationProcessId;
+        $this->action = $action;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(FiltrationService $filtrationService): void
+    {
+        Log::info('ProcessFiltrationStageJob: Executing', [
+            'filtration_process_id' => $this->filtrationProcessId,
+            'action' => $this->action
+        ]);
+
+        // Guard clause: Verify FiltrationProcess is still active
+        $filtrationProcess = FiltrationProcess::find($this->filtrationProcessId);
+        
+        if (!$filtrationProcess) {
+            Log::warning('ProcessFiltrationStageJob: Filtration process not found', [
+                'filtration_process_id' => $this->filtrationProcessId,
+                'action' => $this->action
+            ]);
+            return;
+        }
+
+        if ($filtrationProcess->status !== 'active') {
+            Log::info('ProcessFiltrationStageJob: Filtration process not active, skipping', [
+                'filtration_process_id' => $this->filtrationProcessId,
+                'action' => $this->action,
+                'status' => $filtrationProcess->status
+            ]);
+            return;
+        }
+
+        // Execute the appropriate action
+        try {
+            switch ($this->action) {
+                case 'start_stage_2':
+                    $filtrationService->startStage($this->filtrationProcessId, 2);
+                    break;
+
+                case 'start_stage_3':
+                    $filtrationService->startStage($this->filtrationProcessId, 3);
+                    break;
+
+                case 'start_stage_4':
+                    $filtrationService->startStage($this->filtrationProcessId, 4);
+                    break;
+
+                case 'complete_stage_2':
+                    $filtrationService->completeStage($this->filtrationProcessId, 2);
+                    break;
+
+                case 'complete_stage_3':
+                    $filtrationService->completeStage($this->filtrationProcessId, 3);
+                    break;
+
+                case 'evaluate_stage_4':
+                    $filtrationService->evaluateStage4($this->filtrationProcessId);
+                    break;
+
+                default:
+                    Log::warning('ProcessFiltrationStageJob: Unknown action', [
+                        'filtration_process_id' => $this->filtrationProcessId,
+                        'action' => $this->action
+                    ]);
+                    break;
+            }
+
+            Log::info('ProcessFiltrationStageJob: Completed', [
+                'filtration_process_id' => $this->filtrationProcessId,
+                'action' => $this->action
+            ]);
+
+        } catch (\Exception $e) {
+            Log::error('ProcessFiltrationStageJob: Failed', [
+                'filtration_process_id' => $this->filtrationProcessId,
+                'action' => $this->action,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
+            // Re-throw to allow queue retry mechanism
+            throw $e;
+        }
+    }
+}

--- a/app/Models/FiltrationProcess.php
+++ b/app/Models/FiltrationProcess.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class FiltrationProcess
+ * 
+ * @property int $id
+ * @property int $device_id
+ * @property int $treatment_report_id
+ * @property string $status
+ * @property bool $pump_3_state
+ * @property bool $valve_1_state
+ * @property bool $valve_2_state
+ * @property Carbon|null $stage_1_started_at
+ * @property Carbon|null $stages_2_4_started_at
+ * @property int $restart_count
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * 
+ * @property Device $device
+ * @property TreatmentReport $treatment_report
+ *
+ * @package App\Models
+ */
+class FiltrationProcess extends Model
+{
+    use HasFactory;
+
+    protected $table = 'filtration_processes';
+
+    protected $casts = [
+        'device_id' => 'int',
+        'treatment_report_id' => 'int',
+        'pump_3_state' => 'bool',
+        'valve_1_state' => 'bool',
+        'valve_2_state' => 'bool',
+        'stage_1_started_at' => 'datetime',
+        'stages_2_4_started_at' => 'datetime',
+        'restart_count' => 'int'
+    ];
+
+    protected $fillable = [
+        'device_id',
+        'treatment_report_id',
+        'status',
+        'pump_3_state',
+        'valve_1_state',
+        'valve_2_state',
+        'stage_1_started_at',
+        'stages_2_4_started_at',
+        'restart_count'
+    ];
+
+    public function device()
+    {
+        return $this->belongsTo(Device::class);
+    }
+
+    public function treatment_report()
+    {
+        return $this->belongsTo(TreatmentReport::class);
+    }
+}

--- a/app/Models/TreatmentStage.php
+++ b/app/Models/TreatmentStage.php
@@ -35,7 +35,9 @@ class TreatmentStage extends Model
 		'stage_order' => 'int',
 		'pH' => 'float',
 		'turbidity' => 'float',
-		'TDS' => 'float'
+		'TDS' => 'float',
+		'started_at' => 'datetime',
+		'completed_at' => 'datetime',
 	];
 
 	protected $fillable = [
@@ -46,7 +48,9 @@ class TreatmentStage extends Model
 		'pH',
 		'turbidity',
 		'TDS',
-		'notes'
+		'notes',
+		'started_at',
+		'completed_at',
 	];
 
 	public function treatment_report()

--- a/app/Services/MqttService.php
+++ b/app/Services/MqttService.php
@@ -55,14 +55,20 @@ class MqttService
         $client->connect($settings, true);
     }
 
+    /**
+     * Publish a message to an MQTT topic.
+     *
+     * @param int $qos Quality of Service: 1 = at least once delivery (recommended for reliable frontend sync)
+     */
     public function publish(string $topic, string|array $payload, int $qos = 1, bool $retain = false): void
     {
         try {
             $this->connect();
 
+            $message = is_array($payload) ? json_encode($payload) : $payload;
             $this->client->publish(
                 $topic,
-                json_encode($payload),
+                $message,
                 $qos,
                 $retain
             );

--- a/database/migrations/2026_02_08_000001_create_filtration_processes_table.php
+++ b/database/migrations/2026_02_08_000001_create_filtration_processes_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('filtration_processes', function (Blueprint $table) {
             $table->bigInteger('id', true);
-            $table->bigInteger('device_id')->index('device_id');
+            $table->bigInteger('device_id');
             $table->bigInteger('treatment_report_id')->index('treatment_report_id');
             $table->enum('status', ['active', 'completed', 'failed', 'restarting'])->default('active');
             $table->boolean('pump_3_state')->default(false);

--- a/database/migrations/2026_02_08_000001_create_filtration_processes_table.php
+++ b/database/migrations/2026_02_08_000001_create_filtration_processes_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('filtration_processes', function (Blueprint $table) {
+            $table->bigInteger('id', true);
+            $table->bigInteger('device_id')->index('device_id');
+            $table->bigInteger('treatment_report_id')->index('treatment_report_id');
+            $table->enum('status', ['active', 'completed', 'failed', 'restarting'])->default('active');
+            $table->boolean('pump_3_state')->default(false);
+            $table->boolean('valve_1_state')->default(false);
+            $table->boolean('valve_2_state')->default(false);
+            $table->dateTime('stage_1_started_at')->nullable();
+            $table->dateTime('stages_2_4_started_at')->nullable();
+            $table->integer('restart_count')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('filtration_processes');
+    }
+};

--- a/database/migrations/2026_02_08_000002_add_foreign_keys_to_filtration_processes_table.php
+++ b/database/migrations/2026_02_08_000002_add_foreign_keys_to_filtration_processes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('filtration_processes', function (Blueprint $table) {
+            $table->foreign('device_id')->references('id')->on('devices')->onDelete('cascade');
+            $table->foreign('treatment_report_id')->references('id')->on('treatment_reports')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('filtration_processes', function (Blueprint $table) {
+            $table->dropForeign(['device_id']);
+            $table->dropForeign(['treatment_report_id']);
+        });
+    }
+};

--- a/database/migrations/2026_02_08_000003_add_timestamps_to_treatment_stages_table.php
+++ b/database/migrations/2026_02_08_000003_add_timestamps_to_treatment_stages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('treatment_stages', function (Blueprint $table) {
+            $table->dateTime('started_at')->nullable();
+            $table->dateTime('completed_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('treatment_stages', function (Blueprint $table) {
+            $table->dropColumn(['started_at', 'completed_at']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ use Database\Seeders\HydroponicYieldGradeSeeder;
 use Database\Seeders\TipsSuggestionsSeeder;
 use Database\Seeders\TreatmentStagesSeeder;
 use Database\Seeders\TreatmentReportsSeeder;
+use Database\Seeders\FiltrationProcessSeeder;
 use Database\Seeders\DeviceUserSeeder;
 use Database\Seeders\PairingTokenSeeder;
 use Database\Seeders\AdminSeeder;
@@ -36,6 +37,7 @@ class DatabaseSeeder extends Seeder
             SensorReadingsSeeder::class,
             TreatmentReportsSeeder::class,
             TreatmentStagesSeeder::class,
+            FiltrationProcessSeeder::class, // Seed filtration processes after treatment reports
             HydroponicSetupSeeder::class,
             HydroponicYieldSeeder::class,
             HydroponicYieldGradeSeeder::class,

--- a/database/seeders/FiltrationProcessSeeder.php
+++ b/database/seeders/FiltrationProcessSeeder.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Device;
+use App\Models\FiltrationProcess;
+use App\Models\TreatmentReport;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class FiltrationProcessSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Only seed if we have devices in the database
+        $devices = Device::all();
+        
+        if ($devices->isEmpty()) {
+            $this->command->warn('⚠ No devices found. Please seed devices first before seeding filtration processes.');
+            return;
+        }
+
+        $this->command->info('Seeding filtration processes...');
+
+        // Example 1: Active filtration process (Stage 1 in progress)
+        $device1 = $devices->first();
+        
+        $treatmentReport1 = TreatmentReport::create([
+            'device_id' => $device1->id,
+            'start_time' => now()->subHours(2),
+            'end_time' => null,
+            'final_status' => 'pending',
+            'total_cycles' => null,
+        ]);
+
+        FiltrationProcess::create([
+            'device_id' => $device1->id,
+            'treatment_report_id' => $treatmentReport1->id,
+            'status' => 'active',
+            'pump_3_state' => true,
+            'valve_1_state' => false,
+            'valve_2_state' => false,
+            'stage_1_started_at' => now()->subHours(2),
+            'stages_2_4_started_at' => null,
+            'restart_count' => 0,
+        ]);
+
+        $this->command->info("✓ Created active filtration process for device: {$device1->serial_number}");
+
+        // Example 2: Completed filtration process (if we have more than 1 device)
+        if ($devices->count() > 1) {
+            $device2 = $devices->skip(1)->first();
+            
+            $treatmentReport2 = TreatmentReport::create([
+                'device_id' => $device2->id,
+                'start_time' => now()->subDays(1),
+                'end_time' => now()->subDays(1)->addHours(1),
+                'final_status' => 'success',
+                'total_cycles' => 1,
+            ]);
+
+            FiltrationProcess::create([
+                'device_id' => $device2->id,
+                'treatment_report_id' => $treatmentReport2->id,
+                'status' => 'completed',
+                'pump_3_state' => false,
+                'valve_1_state' => false,
+                'valve_2_state' => false,
+                'stage_1_started_at' => now()->subDays(1),
+                'stages_2_4_started_at' => now()->subDays(1)->addMinutes(30),
+                'restart_count' => 0,
+            ]);
+
+            $this->command->info("✓ Created completed filtration process for device: {$device2->serial_number}");
+        }
+
+        // Example 3: Filtration process with restart (if we have more than 2 devices)
+        if ($devices->count() > 2) {
+            $device3 = $devices->skip(2)->first();
+            
+            $treatmentReport3 = TreatmentReport::create([
+                'device_id' => $device3->id,
+                'start_time' => now()->subHours(3),
+                'end_time' => null,
+                'final_status' => 'pending',
+                'total_cycles' => null,
+            ]);
+
+            FiltrationProcess::create([
+                'device_id' => $device3->id,
+                'treatment_report_id' => $treatmentReport3->id,
+                'status' => 'active',
+                'pump_3_state' => true,
+                'valve_1_state' => false,
+                'valve_2_state' => false,
+                'stage_1_started_at' => now()->subHours(3),
+                'stages_2_4_started_at' => now()->subHours(2),
+                'restart_count' => 2, // This process has been restarted twice
+            ]);
+
+            $this->command->info("✓ Created filtration process with restarts for device: {$device3->serial_number}");
+        }
+
+        $this->command->newLine();
+        $this->command->info(' Filtration process seeding completed!');
+        $this->command->info("Total filtration processes created: " . FiltrationProcess::count());
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,6 +153,7 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::post('v1/feedback', [FeedbackController::class, 'store']);
     Route::get('v1/feedback', [FeedbackController::class, 'index']);
 
+    Route::get('v1/treatment/latest', [TreatmentController::class, 'getLatestTreatmentReport']);
     Route::post('v1/treatment', [TreatmentController::class, 'saveTreatment']);
     Route::put('v1/treatment/update-treatment', [TreatmentController::class, 'updateTreatment']);
     Route::post('v1/treatment/stages', [TreatmentController::class, 'saveTreatmentStage']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Hydroponics\HydroponicSetupController;
 use App\Http\Controllers\Hydroponics\HydroponicYieldController;
 use App\Http\Controllers\TipsSuggestions\TipsController;
 use App\Http\Controllers\Treatment\TreatmentController;
+use App\Http\Controllers\Filtration\FiltrationCommandController;
 use App\Models\HydroponicSetup;
 use App\Models\HydroponicYield;
 use Illuminate\Support\Facades\Broadcast;
@@ -155,6 +156,14 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function () {
 
     Route::get('v1/treatment/latest', [TreatmentController::class, 'getLatestTreatmentReport']);
     Route::post('v1/treatment', [TreatmentController::class, 'saveTreatment']);
+
+    // Filtration commands (frontend calls these instead of publishing MQTT directly; backend publishes command, then state on ack)
+    Route::post('v1/filtration/commands/start-process', [FiltrationCommandController::class, 'startProcess']);
+    Route::post('v1/filtration/commands/open-valve-1', [FiltrationCommandController::class, 'openValve1']);
+    Route::post('v1/filtration/commands/close-valve-1', [FiltrationCommandController::class, 'closeValve1']);
+    Route::post('v1/filtration/commands/open-drain-valve', [FiltrationCommandController::class, 'openDrainValve']);
+    Route::post('v1/filtration/commands/close-drain-valve', [FiltrationCommandController::class, 'closeDrainValve']);
+    Route::post('v1/filtration/commands/restart', [FiltrationCommandController::class, 'restart']);
     Route::put('v1/treatment/update-treatment', [TreatmentController::class, 'updateTreatment']);
     Route::post('v1/treatment/stages', [TreatmentController::class, 'saveTreatmentStage']);
     Route::put('v1/treatment/update-stages', [TreatmentController::class, 'updateTreatmentStage']);


### PR DESCRIPTION
This pull request introduces major improvements to the MQTT backend processing and adds a new controller for handling filtration commands. The MQTT listener is now more robust, with persistent session support, reconnection logic, and detailed topic-based message routing for both sensor and filtration topics. Additionally, a new `FiltrationCommandController` provides API endpoints for frontend control of filtration hardware. There is also a new endpoint for fetching the latest treatment report, including stage data if the report is pending.

**MQTT Backend Improvements**
- Enhanced the `MqttListen` command to support persistent MQTT sessions, robust reconnection (with configurable delays), and dynamic client IDs based on user or device. Improved error handling ensures clean disconnects and logs issues for debugging. The command now subscribes to additional filtration-related topics and routes messages to topic-specific handlers. [[1]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R5-R7) [[2]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65L14-R25) [[3]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65L33-R93) [[4]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65L72-R108) [[5]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65L82-R141) [[6]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R152-R293)

- Implemented detailed topic-based message handling in `MqttListen`, including parsing and acting on a variety of filtration-related MQTT topics (such as pump and valve acknowledgements and state changes), and delegating to the `FiltrationService` as appropriate.

**Filtration Command API**
- Added a new `FiltrationCommandController` with endpoints for starting the filtration process, opening/closing valves, opening/closing the drain valve, and restarting the pump. The controller ensures commands are only sent for devices owned by the authenticated user and provides clear success/error responses.

**Treatment Report API**
- Added a method to `TreatmentController` to fetch the latest treatment report for the user's device, including detailed stage data if the report is pending, enabling the frontend to display real-time stage statuses.