### PR TITLE
Add device heartbeat monitoring and treatment report enhancements

### DIFF
--- a/app/Console/Commands/CheckDeviceHeartbeat.php
+++ b/app/Console/Commands/CheckDeviceHeartbeat.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Device;
+use App\Services\FiltrationService;
+use Illuminate\Console\Command;
+
+class CheckDeviceHeartbeat extends Command
+{
+    protected $signature = 'device:check-heartbeat
+                            {--timeout=90 : Seconds without heartbeat to consider device offline}';
+    protected $description = 'Mark devices offline when heartbeat has not been received within timeout; pause treatment if valve 1 open and dirty water > 6%';
+
+    public function __construct(
+        protected FiltrationService $filtrationService
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $timeoutSeconds = (int) $this->option('timeout');
+        $threshold = now()->subSeconds($timeoutSeconds);
+
+        $devices = Device::where('status', 'online')
+            ->where(function ($q) use ($threshold) {
+                $q->whereNull('last_heartbeat_at')
+                    ->orWhere('last_heartbeat_at', '<', $threshold);
+            })
+            ->get();
+
+        foreach ($devices as $device) {
+            $this->info("Device {$device->serial_number} (id={$device->id}) marked offline (no heartbeat since " . ($device->last_heartbeat_at?->toDateTimeString() ?? 'never') . ')');
+            $device->update(['status' => 'offline']);
+            $this->filtrationService->onDeviceOffline($device);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Jobs/CheckDeviceOfflineJob.php
+++ b/app/Jobs/CheckDeviceOfflineJob.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Device;
+use App\Services\FiltrationService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Dispatched 90 seconds after a heartbeat is received.
+ * If no newer heartbeat arrived, marks the device offline and pauses treatment if needed (valve 1 open, dirty water > 6%).
+ */
+class CheckDeviceOfflineJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public string $deviceSerial
+    ) {}
+
+    public function handle(FiltrationService $filtrationService): void
+    {
+        $device = Device::where('serial_number', $this->deviceSerial)->first();
+        if (!$device) {
+            return;
+        }
+
+        $device->refresh();
+        $threshold = now()->subSeconds(90);
+        $lastHeartbeat = $device->last_heartbeat_at;
+
+        if ($lastHeartbeat !== null && $lastHeartbeat->gte($threshold)) {
+            // A heartbeat arrived in the last 90 seconds – still online, do nothing
+            return;
+        }
+
+        if ($device->status === 'offline') {
+            return;
+        }
+
+        Log::info('CheckDeviceOfflineJob: Marking device offline (no heartbeat within 90s)', [
+            'serial' => $this->deviceSerial,
+            'last_heartbeat_at' => $lastHeartbeat?->toDateTimeString(),
+        ]);
+
+        $device->update(['status' => 'offline']);
+        $filtrationService->onDeviceOffline($device);
+    }
+}

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -19,6 +19,11 @@ class Device extends Model
         'model',
         'firmware_version',
         'status',
+        'last_heartbeat_at',
+    ];
+
+    protected $casts = [
+        'last_heartbeat_at' => 'datetime',
     ];
 
     /**
@@ -63,5 +68,13 @@ class Device extends Model
     public function hydroponic_setups()
     {
         return $this->hasMany(HydroponicSetup::class);
+    }
+
+    /**
+     * Active or paused filtration process (one per device at a time).
+     */
+    public function filtration_processes()
+    {
+        return $this->hasMany(FiltrationProcess::class);
     }
 }

--- a/app/Models/TreatmentReport.php
+++ b/app/Models/TreatmentReport.php
@@ -20,7 +20,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property Carbon|null $end_time
  * @property string|null $final_status
  * @property int|null $total_cycles
- * 
+ * @property int|null $water_liters
+ *
  * @property Device $device
  * @property Collection|TreatmentStage[] $treatment_stages
  *
@@ -37,7 +38,8 @@ class TreatmentReport extends Model
 		'device_id' => 'int',
 		'start_time' => 'datetime',
 		'end_time' => 'datetime',
-		'total_cycles' => 'int'
+		'total_cycles' => 'int',
+		'water_liters' => 'int'
 	];
 
 	protected $fillable = [
@@ -45,7 +47,8 @@ class TreatmentReport extends Model
 		'start_time',
 		'end_time',
 		'final_status',
-		'total_cycles'
+		'total_cycles',
+		'water_liters'
 	];
 
 	public function device()

--- a/database/migrations/2026_02_21_231635_add_water_liters_column.php
+++ b/database/migrations/2026_02_21_231635_add_water_liters_column.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('treatment_reports', function (Blueprint $table) {
+            $table->integer('water_liters')->nullable()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2026_03_01_000001_add_last_heartbeat_at_to_devices_table.php
+++ b/database/migrations/2026_03_01_000001_add_last_heartbeat_at_to_devices_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     * Used to detect device offline when heartbeat stops (e.g. no heartbeat for 90s).
+     */
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->timestamp('last_heartbeat_at')->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('last_heartbeat_at');
+        });
+    }
+};

--- a/database/migrations/2026_03_01_000002_add_paused_status_to_filtration_processes_table.php
+++ b/database/migrations/2026_03_01_000002_add_paused_status_to_filtration_processes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     * Paused = treatment paused due to device offline (valve 1 was open, water in anode).
+     */
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE filtration_processes MODIFY COLUMN status ENUM('active','paused','completed','failed','restarting') DEFAULT 'active'");
+        }
+        // SQLite and others: enum is stored as string, so 'paused' is already allowed
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE filtration_processes MODIFY COLUMN status ENUM('active','completed','failed','restarting') DEFAULT 'active'");
+        }
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -155,6 +155,7 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::get('v1/feedback', [FeedbackController::class, 'index']);
 
     Route::get('v1/treatment/latest', [TreatmentController::class, 'getLatestTreatmentReport']);
+    Route::get('v1/treatment/reports', [TreatmentController::class, 'getAllTreatmentReports']);
     Route::post('v1/treatment', [TreatmentController::class, 'saveTreatment']);
 
     // Filtration commands (frontend calls these instead of publishing MQTT directly; backend publishes command, then state on ack)


### PR DESCRIPTION
This pull request introduces device heartbeat monitoring and treatment pause/resume logic, along with improvements to the treatment reporting API. Devices are now marked offline if no heartbeat is received within 90 seconds, and treatments are paused or resumed based on device connectivity and water level conditions. Additionally, treatment reports now include the amount of water processed. Several migrations support these changes.

**Device Heartbeat Monitoring and Treatment Pause/Resume**

* Added a scheduled command (`CheckDeviceHeartbeat`) and a queued job (`CheckDeviceOfflineJob`) to mark devices offline if no heartbeat is received within the timeout period. When a device is marked offline, any active treatment is paused if valve 1 is open and the dirty water level is above 6%. [[1]](diffhunk://#diff-fd51a7b503c97987130c029d093612e44e32c27bbca83aa27639cd1e84615445R1-R41) [[2]](diffhunk://#diff-2305389b3c2520aeab4291f4e5f1829399805a987a1d429059ab98ea2c0f71d1R1-R54) [[3]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfR504-R590)
* Updated MQTT listener to handle heartbeat messages (`biotech/{serial}/heartbeat`), marking devices online and resuming paused treatments if appropriate. [[1]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R86) [[2]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R157-R158) [[3]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R194-R207) [[4]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfR504-R590)
* Filtration process logic now supports a `paused` status, allowing processes to be paused/resumed based on device connectivity and valve state. [[1]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfL111-R131) [[2]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfL190-R204) [[3]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfR217-R227) [[4]](diffhunk://#diff-87bff51c7e8251447f5521f02abe23934de86401df2435bd22e966542d10aa54R1-R33)

**Treatment Reporting Enhancements**

* Treatment reports now include a `water_liters` field, which is set when a treatment is completed and returned in API responses. [[1]](diffhunk://#diff-8eaef702e3b738a41d6a8083dc9fdfc01116499002143096a85ad943f65cc79fR13-R70) [[2]](diffhunk://#diff-8eaef702e3b738a41d6a8083dc9fdfc01116499002143096a85ad943f65cc79fR117) [[3]](diffhunk://#diff-8eaef702e3b738a41d6a8083dc9fdfc01116499002143096a85ad943f65cc79fR289-R295) [[4]](diffhunk://#diff-0926ea1e30921964590fe579715fee2d077fa71e95fab88adcc77caae30c922aR23) [[5]](diffhunk://#diff-0926ea1e30921964590fe579715fee2d077fa71e95fab88adcc77caae30c922aL40-R51) [[6]](diffhunk://#diff-c6d959042e3e802cde6ef2e9d1da056fce417a0d01b414da616f4f004e2367acR1-R26)

**Model and Migration Updates**

* Added `last_heartbeat_at` field to `Device` model and database for tracking heartbeat timestamps. [[1]](diffhunk://#diff-56d0c99da95b2d1d1621c1b694577893589ba6560b344eab93142ccad8c49ff6R22-R26) [[2]](diffhunk://#diff-9617744cc3ea67b1c53c935943a211f3cd7b04b853b4b512956370a2ddf21dd4R1-R29)
* Added `filtration_processes` relation to `Device` model for easier access to related processes.
* Updated filtration process status enum to support the new `paused` status.- Introduced CheckDeviceHeartbeat command to mark devices offline if no heartbeat is received within a specified timeout.
- Implemented CheckDeviceOfflineJob to handle device status updates after a heartbeat delay.
- Enhanced MqttListen command to process heartbeat messages and dispatch jobs for offline checks.
- Added last_heartbeat_at column to devices and water_liters column to treatment_reports for better tracking.
- Updated FiltrationService to pause treatment processes when devices go offline under specific conditions.
- Created new API endpoint to retrieve all treatment reports for a user's device, including treatment stages.