### PR TITLE
Backend/fix dashboard hydroponics

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\HydroponicSetup;
 use App\Models\SensorSystem;
 use App\Models\SensorReading;
+use App\Models\DeviceUser;
 use Illuminate\Http\Request;
 
 class DashboardController extends Controller
@@ -29,19 +30,25 @@ class DashboardController extends Controller
         $user = $request->user();
         $deviceId = $request->input('device_id', 1); // Default to device 1
 
+        // Check if the user is connected to the device
+        $isConnected = DeviceUser::where('user_id', $user->id)
+            ->where('device_id', $deviceId)
+            ->exists();
+
+        if (!$isConnected) {
+            return response()->json([
+                'user' => $user->first_name ?? $user->name,
+                'ph_levels' => [],
+                'nearest_to_harvest' => null,
+            ]);
+        }
+
         // Get all sensor systems for the device with their latest readings
         $sensorSystems = SensorSystem::where('device_id', $deviceId)
     ->where('is_active', true)
     ->where('system_type', '=', 'clean_water')
     ->with('latestReading')
     ->get();
-
-        if ($sensorSystems->isEmpty()) {
-            return response()->json([
-                'message' => 'No active sensor systems found for this device.',
-                'device_id' => $deviceId,
-            ], 404);
-        }
 
         // Format the response with only pH data
         $phData = [];

--- a/app/Http/Controllers/Hydroponics/HydroponicYieldController.php
+++ b/app/Http/Controllers/Hydroponics/HydroponicYieldController.php
@@ -172,6 +172,38 @@ class HydroponicYieldController extends Controller
         ]);
     }
 
+    public function getSetupYield(HydroponicSetup $setup)
+    {
+        $setup->load('hydroponic_yields.grades');
+        
+        $yield = $setup->hydroponic_yields->first();
+
+        if (!$yield) {
+            return response()->json([
+                'status' => 'success',
+                'data' => null,
+            ]);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'data' => [
+                'id' => $yield->id,
+                'total_count' => $yield->total_count,
+                'total_weight' => $yield->total_weight,
+                'notes' => $yield->notes,
+                'grades' => $yield->grades->map(function ($grade) {
+                    return [
+                        'id' => $grade->id,
+                        'grade' => $grade->grade,
+                        'count' => $grade->count,
+                        'weight' => $grade->weight,
+                    ];
+                }),
+            ],
+        ]);
+    }
+
     public function storeYield(StoreYieldRequest $request, HydroponicSetup $setup)
     {
         $validated = $request->validated();

--- a/app/Http/Requests/Hydroponics/StoreHydroponicsRequest.php
+++ b/app/Http/Requests/Hydroponics/StoreHydroponicsRequest.php
@@ -35,4 +35,57 @@ class StoreHydroponicsRequest extends FormRequest
             'harvest_date' => 'required|date',
         ];
     }
+
+    /**
+     * Get custom error messages for validation rules.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'crop_name.required' => 'Please enter the name of the crop you want to grow.',
+            'crop_name.max' => 'The crop name is too long. Please use 255 characters or less.',
+            
+            'number_of_crops.required' => 'Please specify how many crops you want to grow.',
+            'number_of_crops.integer' => 'The number of crops must be a whole number.',
+            'number_of_crops.min' => 'You must grow at least 1 crop.',
+            'number_of_crops.max' => 'You can grow a maximum of 1000 crops at once.',
+            
+            'bed_size.required' => 'Please select a bed size for your hydroponic system.',
+            'bed_size.in' => 'Please choose a valid bed size: small, medium, large, or custom.',
+            
+            'nutrient_solution.max' => 'The nutrient solution name is too long. Please use 255 characters or less.',
+            
+            'target_ph_min.required' => 'Please enter the minimum pH level for your crops.',
+            'target_ph_min.numeric' => 'The minimum pH must be a number.',
+            'target_ph_min.min' => 'The minimum pH must be at least 1.',
+            'target_ph_min.max' => 'The minimum pH cannot exceed 14.',
+            
+            'target_ph_max.required' => 'Please enter the maximum pH level for your crops.',
+            'target_ph_max.numeric' => 'The maximum pH must be a number.',
+            'target_ph_max.min' => 'The maximum pH must be at least 1.',
+            'target_ph_max.max' => 'The maximum pH cannot exceed 14.',
+            'target_ph_max.gte' => 'The maximum pH must be greater than or equal to the minimum pH.',
+            
+            'target_tds_min.required' => 'Please enter the minimum TDS (Total Dissolved Solids) level in PPM.',
+            'target_tds_min.integer' => 'The minimum TDS must be a whole number.',
+            'target_tds_min.min' => 'The minimum TDS must be at least 200 PPM.',
+            'target_tds_min.max' => 'The minimum TDS cannot exceed 1500 PPM.',
+            
+            'target_tds_max.required' => 'Please enter the maximum TDS (Total Dissolved Solids) level in PPM.',
+            'target_tds_max.integer' => 'The maximum TDS must be a whole number.',
+            'target_tds_max.min' => 'The maximum TDS must be at least 200 PPM.',
+            'target_tds_max.max' => 'The maximum TDS cannot exceed 1500 PPM.',
+            'target_tds_max.gte' => 'The maximum TDS must be greater than or equal to the minimum TDS.',
+            
+            'water_amount.required' => 'Please specify the amount of water in liters.',
+            'water_amount.integer' => 'The water amount must be a whole number.',
+            'water_amount.min' => 'You must use at least 1 liter of water.',
+            'water_amount.max' => 'The maximum water amount is 100 liters.',
+            
+            'harvest_date.required' => 'Please select an expected harvest date.',
+            'harvest_date.date' => 'Please enter a valid date for the harvest.',
+        ];
+    }
 }

--- a/app/Http/Requests/Hydroponics/StoreHydroponicsRequest.php
+++ b/app/Http/Requests/Hydroponics/StoreHydroponicsRequest.php
@@ -28,9 +28,9 @@ class StoreHydroponicsRequest extends FormRequest
             'pump_config' => 'nullable|array',
             'nutrient_solution' => 'nullable|string|max:255',
             'target_ph_min' => 'required|numeric|min:1|max:14',
-            'target_ph_max' => 'required|numeric|min:1|max:14',
-            'target_tds_min' => 'required|integer|min:1|max:10000',
-            'target_tds_max' => 'required|integer|min:1|max:10000',
+            'target_ph_max' => 'required|numeric|min:1|max:14|gte:target_ph_min',
+            'target_tds_min' => 'required|integer|min:200|max:1500',
+            'target_tds_max' => 'required|integer|min:200|max:1500|gte:target_tds_min',
             'water_amount' => 'required|integer|min:1|max:100',
             'harvest_date' => 'required|date',
         ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -143,8 +143,9 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::post('v1/hydroponic-setups/{setup}/mark-harvested',[HydroponicSetupController::class, 'markAsHarvested']);
 
     Route::get('v1/hydroponic-yields', [HydroponicYieldController::class, 'index']);
-    Route::get('v1/hydroponic-yields/{setup}', [HydroponicYieldController::class, 'show']);
+    Route::get('v1/hydroponic-yields/{setup}/yield', [HydroponicYieldController::class, 'getSetupYield']);
     Route::post('v1/hydroponic-yields/{setup}/store', [HydroponicYieldController::class, 'storeYield']);
+    Route::get('v1/hydroponic-yields/{setup}', [HydroponicYieldController::class, 'show']);
 
     Route::post('v1/tips/rag-insights', [TipsController::class, 'generateRagInsights']);
 

--- a/tests/Feature/Dashboard/DashboardTest.php
+++ b/tests/Feature/Dashboard/DashboardTest.php
@@ -80,7 +80,7 @@ describe('Dashboard Overview', function () {
             ]);
     });
 
-    it('returns 404 when pH sensor does not exist', function () {
+    it('returns empty pH levels when sensor does not exist', function () {
         $device = Device::factory()->create();
         $device->users()->attach($this->user->id);
 
@@ -89,10 +89,12 @@ describe('Dashboard Overview', function () {
         $response = $this->actingAs($this->user)
             ->getJson('/api/v1/dashboard?device_id=' . $device->id);
 
-        $response->assertStatus(404)
+        $response->assertStatus(200)
             ->assertJson([
-                'message' => 'No active sensor systems found for this device.',
+                'user' => $this->user->first_name ?? $this->user->name,
                 'device_id' => $device->id,
+                'ph_levels' => [],
+                'nearest_to_harvest' => null,
             ]);
     });
 


### PR DESCRIPTION
This pull request introduces several improvements and adjustments to the hydroponics dashboard and yield APIs, focusing on access control, validation, user feedback, and API consistency. The most significant changes are grouped below:

**Dashboard Access and Response Handling:**

* The dashboard now checks if the authenticated user is connected to the requested device using the `DeviceUser` model. If not connected, it returns an empty pH levels array and `nearest_to_harvest` as null, improving security and user feedback. [[1]](diffhunk://#diff-e1edb5910a1a7937937cf1d2f029d265db4287010d8c53f62b79956458bee4edR9) [[2]](diffhunk://#diff-e1edb5910a1a7937937cf1d2f029d265db4287010d8c53f62b79956458bee4edR33-L45)
* The related test was updated to expect a 200 response with empty pH data when the sensor does not exist, aligning with the new controller logic and making the API more predictable for clients. [[1]](diffhunk://#diff-3aa772039a6bb1ffaa877410805ea505d736740596ace116a73c589ebf263cd7L83-R83) [[2]](diffhunk://#diff-3aa772039a6bb1ffaa877410805ea505d736740596ace116a73c589ebf263cd7L92-R97)

**Hydroponic Yield API Enhancements:**

* Added a new `getSetupYield` method in `HydroponicYieldController` to fetch yield data (with grades) for a specific setup, returning a consistent JSON structure even if no yield exists. The corresponding route was also added. [[1]](diffhunk://#diff-5d9f5e2cc47b37913a93df766f03209e64703893fc78693cde56f9cb8f1e57afR175-R206) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL146-R148)

**Validation and User Feedback Improvements:**

* Updated validation rules in `StoreHydroponicsRequest` to enforce logical min/max constraints for pH and TDS values (e.g., `target_ph_max` must be greater than or equal to `target_ph_min`, and TDS min/max are now within 200–1500 PPM).
* Added detailed, user-friendly custom error messages for all validation rules, improving clarity for API consumers and frontend users.