### PR TITLE
Enhance water usage analytics in ReportsController

### DIFF
--- a/app/Http/Controllers/Reports/ReportsController.php
+++ b/app/Http/Controllers/Reports/ReportsController.php
@@ -730,6 +730,9 @@ class ReportsController extends Controller
                     'average_duration' => 0,
                     'stage_efficiency' => null,
                     'failure_analysis' => null,
+                    'total_water_processed' => 0,
+                    'average_water_per_cycle' => 0,
+                    'total_water_liters' => 0,
                 ],
                 'meta' => [
                     'device_id' => $deviceId,
@@ -822,6 +825,13 @@ class ReportsController extends Controller
             2
         );
 
+        // Water usage analytics
+        $totalWaterProcessed = $reports->sum('water_liters');
+        $averageWaterPerCycle = $reports->count() > 0
+            ? round($totalWaterProcessed / $reports->count(), 2)
+            : 0;
+        $latestTotalWater = $reports->sortByDesc('start_time')->first()?->total_water_liters ?? 0;
+
         return response()->json([
             'status' => 'success',
             'data' => [
@@ -833,6 +843,9 @@ class ReportsController extends Controller
                 'average_improvements' => $averageImprovements,
                 'failure_analysis' => $failureAnalysis,
                 'performance_score' => $performanceScore,
+                'total_water_processed' => $totalWaterProcessed,
+                'average_water_per_cycle' => $averageWaterPerCycle,
+                'total_water_liters' => $latestTotalWater,
             ],
             'meta' => [
                 'device_id' => $deviceId,
@@ -894,6 +907,8 @@ class ReportsController extends Controller
                     'success_rate_trend' => [],
                     'efficiency_score_trend' => 'stable',
                     'maintenance_recommendation' => null,
+                    'total_water_processed' => 0,
+                    'average_water_per_day' => 0,
                 ],
                 'meta' => [
                     'device_id' => $deviceId,
@@ -939,6 +954,7 @@ class ReportsController extends Controller
             $cycleTrends[] = [
                 'date' => $date,
                 'cycle_count' => $dayReports->count(),
+                'water_liters' => $dayReports->sum('water_liters'),
             ];
 
             $successRate = $dayReports->where('final_status', 'success')->count() / $dayReports->count() * 100;
@@ -980,6 +996,10 @@ class ReportsController extends Controller
             $maintenanceRecommendation = 'Low cycle frequency detected. Verify system is operating as expected.';
         }
 
+        // Water usage analytics
+        $totalWaterProcessed = $reports->sum('water_liters');
+        $averageWaterPerDay = $days > 0 ? round($totalWaterProcessed / $days, 2) : 0;
+
         return response()->json([
             'status' => 'success',
             'data' => [
@@ -990,6 +1010,8 @@ class ReportsController extends Controller
                 'efficiency_score_trend' => $efficiencyTrend,
                 'recent_success_rate' => $recentSuccessRate,
                 'maintenance_recommendation' => $maintenanceRecommendation,
+                'total_water_processed' => $totalWaterProcessed,
+                'average_water_per_day' => $averageWaterPerDay,
             ],
             'meta' => [
                 'device_id' => $deviceId,


### PR DESCRIPTION
This pull request enhances the water usage analytics in the treatment performance and efficiency report endpoints. It introduces new metrics for water processed and average usage, both at the cycle and daily levels, and ensures these are included in the API responses even when no data is available.

**Water usage analytics improvements:**

* Added `total_water_processed`, `average_water_per_cycle`, and `total_water_liters` to the treatment performance report response, with appropriate calculations and default values. [[1]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R733-R735) [[2]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R828-R834) [[3]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R846-R848)
* Added `total_water_processed` and `average_water_per_day` to the treatment efficiency report response, with calculations and default values. [[1]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R910-R911) [[2]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R999-R1002) [[3]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R1013-R1014)
* Included `water_liters` per day in the cycle trends data for the efficiency report.- Added total water processed, average water per cycle, and total water liters to treatment performance and efficiency methods.
- Implemented calculations for water usage analytics to provide better insights in the response data.
- Updated response structure to include new water metrics for improved reporting.