### PR TITLE
Develop

### DIFF
--- a/app/Console/Commands/CheckDeviceHeartbeat.php
+++ b/app/Console/Commands/CheckDeviceHeartbeat.php
@@ -9,8 +9,8 @@ use Illuminate\Console\Command;
 class CheckDeviceHeartbeat extends Command
 {
     protected $signature = 'device:check-heartbeat
-                            {--timeout=90 : Seconds without heartbeat to consider device offline}';
-    protected $description = 'Mark devices offline when heartbeat has not been received within timeout; pause treatment if valve 1 open and dirty water > 6%';
+                            {--timeout=60 : Seconds without heartbeat to consider device offline}';
+    protected $description = 'Mark devices offline when heartbeat has not been received within timeout (IoT publishes every 45s); pause treatment if valve 1 open and dirty water > 6%';
 
     public function __construct(
         protected FiltrationService $filtrationService

--- a/app/Console/Commands/MqttListen.php
+++ b/app/Console/Commands/MqttListen.php
@@ -13,8 +13,8 @@ use Illuminate\Support\Facades\Log;
 
 class MqttListen extends Command
 {
-    protected $signature = 'mqtt:listen {--device-id=1 : Device ID to associate with readings}';
-    protected $description = 'Listen to MQTT sensor topics continuously (runs forever until process is stopped; auto-reconnects on disconnect)';
+    protected $signature = 'mqtt:listen {--device-id=1 : Device ID to listen for}';
+    protected $description = 'Listen to MQTT topics for a specific device (runs forever until process is stopped; only processes messages for the specified device-id)';
 
     protected $sensorHandler;
     protected $filtrationService;
@@ -159,7 +159,7 @@ class MqttListen extends Command
             if ($topic === 'hydronew/ai-classification/backend') {
                 $this->handleAIClassificationTopic($message);
             } elseif (preg_match('#^biotech/([^/]+)/heartbeat$#', $topic, $matches)) {
-                $this->handleHeartbeatTopic($matches[1]);
+                $this->handleHeartbeatTopic($matches[1], $message);
             } else {
                 $this->handleFiltrationTopic($topic, $message);
             }
@@ -191,22 +191,57 @@ class MqttListen extends Command
             return;
         }
 
+        // Check if this message is for the device this listener is monitoring
+        $serialNumber = $data['device_serial_number'] ?? null;
+        if ($serialNumber && !$this->isListenerDevice($serialNumber)) {
+            $this->line("ℹ Ignoring AI classification for device {$serialNumber} - not linked to this listener");
+            return;
+        }
+
         $this->sensorHandler->handleAIClassificationPayload($data);
         $this->info("✓ Processed AI classification data");
     }
 
     /**
-     * Handle biotech/{serial}/heartbeat – device is online.
+     * Handle biotech/{serial}/heartbeat – device status update.
+     * IoT publishes heartbeat every 45 seconds with payload "1" (online) or "0" (offline).
      * Updates device status and last_heartbeat_at; if a paused treatment has water in anode, re-opens valve 1.
-     * Dispatches a job to run in 90s: if no newer heartbeat by then, device is marked offline.
+     * For online status: Dispatches a job to run in 60s to check if device went offline.
+     * Only processes heartbeat if the device is linked to this listener's device_id.
      */
-    protected function handleHeartbeatTopic(string $serial): void
+    protected function handleHeartbeatTopic(string $serial, string $message): void
     {
-        $this->info("✓ Heartbeat received for device {$serial}");
-        $this->filtrationService->onDeviceOnline($serial);
+        $device = $this->isListenerDevice($serial);
+        
+        if (!$device) {
+            $this->line("ℹ Ignoring heartbeat for device {$serial} - not linked to this listener");
+            return;
+        }
 
-        CheckDeviceOfflineJob::dispatch($serial)
-            ->delay(now()->addSeconds(90));
+        // Parse heartbeat payload: 1 = online, 0 = offline
+        $heartbeatValue = (int)trim($message);
+        
+        if ($heartbeatValue === 1) {
+            // Device is online
+            $this->info("✓ Heartbeat received for device {$serial} (status: online)");
+            $this->filtrationService->onDeviceOnline($serial);
+            
+            // Schedule offline check in 60 seconds
+            CheckDeviceOfflineJob::dispatch($serial)
+                ->delay(now()->addSeconds(60));
+                
+        } elseif ($heartbeatValue === 0) {
+            // Device explicitly went offline
+            $this->warn("⚠ Device {$serial} reported offline status");
+            
+            // Update device status to offline
+            $device->update(['status' => 'offline']);
+            $this->filtrationService->onDeviceOffline($device);
+            
+        } else {
+            // Invalid heartbeat value
+            $this->warn("⚠ Invalid heartbeat value '{$message}' for device {$serial} (expected 0 or 1)");
+        }
     }
 
     protected function handleFiltrationTopic(string $topic, string $message): void
@@ -231,6 +266,9 @@ class MqttListen extends Command
         // Parse pump/3 ack: only process when ack=1 (command executed). ack=0 means did not execute.
         if (preg_match('#^mfc/([^/]+)/pump/3/ack$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             if ($value !== 1) {
                 $this->warn("⚠ Pump 3 ack=0 for device {$serial} (command did not execute, skipping)");
                 return;
@@ -243,6 +281,9 @@ class MqttListen extends Command
         // Parse valve/1 ack: when ack=1, update state and publish so frontend stays in sync (in case IoT didn't send state)
         if (preg_match('#^mfc/([^/]+)/valve/1/ack$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             if ($value !== 1) {
                 $this->warn("⚠ Valve 1 ack=0 for device {$serial} (command did not execute, skipping)");
                 return;
@@ -255,6 +296,9 @@ class MqttListen extends Command
         // Parse valve/1 state (we track state changes from IoT)
         if (preg_match('#^mfc/([^/]+)/valve/1/state$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             $this->info("✓ Valve 1 state={$value} for device {$serial}");
             $this->filtrationService->handleValve1State($serial, $value);
             return;
@@ -263,6 +307,9 @@ class MqttListen extends Command
         // Parse valve/2 ack (drain valve): when ack=1, update state and publish so frontend stays in sync
         if (preg_match('#^mfc_fallback/([^/]+)/valve/2/ack$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             if ($value !== 1) {
                 $this->warn("⚠ Valve 2 (drain) ack=0 for device {$serial} (command did not execute, skipping)");
                 return;
@@ -275,6 +322,9 @@ class MqttListen extends Command
         // Parse valve/2 state (drain valve)
         if (preg_match('#^mfc_fallback/([^/]+)/valve/2/state$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             $this->info("✓ Valve 2 (drain) state={$value} for device {$serial}");
             $this->filtrationService->handleValve2State($serial, $value);
             return;
@@ -283,6 +333,9 @@ class MqttListen extends Command
         // Parse restart pump/1 ack: only process when ack=1 (command executed). ack=0 means did not execute.
         if (preg_match('#^reservoir_fallback/([^/]+)/pump/1/ack$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             if ($value !== 1) {
                 $this->warn("⚠ Restart pump ack=0 for device {$serial} (command did not execute, skipping)");
                 return;
@@ -295,6 +348,9 @@ class MqttListen extends Command
         // Parse pump/4 ack: toggle state and publish when ack=1.
         if (preg_match('#^reservoir/([^/]+)/pump/4/ack$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             if ($value !== 1) {
                 $this->warn("⚠ Pump 4 ack=0 for device {$serial} (command did not execute, skipping)");
                 return;
@@ -307,6 +363,9 @@ class MqttListen extends Command
         // Parse pump/4 state
         if (preg_match('#^reservoir/([^/]+)/pump/4/state$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             $this->info("✓ Pump 4 state={$value} for device {$serial}");
             $this->filtrationService->handlePump4State($serial, $value);
             return;
@@ -315,6 +374,9 @@ class MqttListen extends Command
         // Parse pump/2 ack: toggle state and publish when ack=1.
         if (preg_match('#^hydroponics/([^/]+)/pump/2/ack$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             if ($value !== 1) {
                 $this->warn("⚠ Pump 2 ack=0 for device {$serial} (command did not execute, skipping)");
                 return;
@@ -327,6 +389,9 @@ class MqttListen extends Command
         // Parse pump/2 state
         if (preg_match('#^hydroponics/([^/]+)/pump/2/state$#', $topic, $matches)) {
             $serial = $matches[1];
+            if (!$this->isListenerDevice($serial)) {
+                return;
+            }
             $this->info("✓ Pump 2 state={$value} for device {$serial}");
             $this->filtrationService->handlePump2State($serial, $value);
             return;
@@ -357,5 +422,26 @@ class MqttListen extends Command
         }
 
         return 'device_' . $deviceId;
+    }
+
+    /**
+     * Check if the given serial number belongs to the device this listener is monitoring.
+     * Returns the device if it matches, null otherwise.
+     */
+    protected function isListenerDevice(string $serial): ?Device
+    {
+        $device = Device::where('serial_number', $serial)->first();
+        
+        if (!$device) {
+            return null;
+        }
+
+        $listenerDeviceId = (int) $this->option('device-id');
+        
+        if ($device->id !== $listenerDeviceId) {
+            return null;
+        }
+
+        return $device;
     }
 }

--- a/app/Http/Controllers/Reports/ReportsController.php
+++ b/app/Http/Controllers/Reports/ReportsController.php
@@ -685,12 +685,35 @@ class ReportsController extends Controller
      */
     public function treatmentPerformance(TreatmentReportRequest $request): JsonResponse
     {
+        $user = $request->user();
         $validated = $request->validated();
-        $deviceId = $validated['device_id'];
+        
+        // Check if user has any connected devices
+        if ($user->devices->isEmpty()) {
+            return response()->json([
+                'status' => 'success',
+                'message' => 'No Data Available',
+                'data' => null,
+            ], 200);
+        }
+
+        // If device_id is not provided, use the first device
+        $deviceId = $validated['device_id'] ?? $user->devices->first()->id;
+        
+        // Verify the device belongs to the authenticated user
+        $device = $user->devices->where('id', $deviceId)->first();
+        
+        if (!$device) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Device not found or does not belong to the user.',
+            ], 403);
+        }
+        
         $dateFrom = $validated['date_from'] ?? Carbon::now()->subDays(30)->toDateString();
         $dateTo = $validated['date_to'] ?? Carbon::now()->toDateString();
 
-        // Get treatment reports within date range
+        // Get treatment reports within date range for this specific device
         $reports = TreatmentReport::where('device_id', $deviceId)
             ->whereBetween('start_time', [$dateFrom, $dateTo])
             ->with('treatment_stages')
@@ -699,6 +722,7 @@ class ReportsController extends Controller
         if ($reports->isEmpty()) {
             return response()->json([
                 'status' => 'success',
+                'message' => 'No Data Available',
                 'data' => [
                     'total_cycles' => 0,
                     'success_rate' => 0,
@@ -824,13 +848,36 @@ class ReportsController extends Controller
      */
     public function treatmentEfficiency(TreatmentReportRequest $request): JsonResponse
     {
+        $user = $request->user();
         $validated = $request->validated();
-        $deviceId = $validated['device_id'];
+        
+        // Check if user has any connected devices
+        if ($user->devices->isEmpty()) {
+            return response()->json([
+                'status' => 'success',
+                'message' => 'No Data Available',
+                'data' => null,
+            ], 200);
+        }
+        
+        // If device_id is not provided, use the first device
+        $deviceId = $validated['device_id'] ?? $user->devices->first()->id;
+        
+        // Verify the device belongs to the authenticated user
+        $device = $user->devices->where('id', $deviceId)->first();
+        
+        if (!$device) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Device not found or does not belong to the user.',
+            ], 403);
+        }
+        
         $days = $validated['days'] ?? 30;
 
         $dateFrom = Carbon::now()->subDays($days)->startOfDay();
 
-        // Get treatment reports
+        // Get treatment reports for this specific device
         $reports = TreatmentReport::where('device_id', $deviceId)
             ->where('start_time', '>=', $dateFrom)
             ->with('treatment_stages')
@@ -840,6 +887,7 @@ class ReportsController extends Controller
         if ($reports->isEmpty()) {
             return response()->json([
                 'status' => 'success',
+                'message' => 'No Data Available',
                 'data' => [
                     'water_quality_improvements' => null,
                     'cycle_trends' => [],

--- a/app/Http/Controllers/Reports/ReportsController.php
+++ b/app/Http/Controllers/Reports/ReportsController.php
@@ -730,6 +730,9 @@ class ReportsController extends Controller
                     'average_duration' => 0,
                     'stage_efficiency' => null,
                     'failure_analysis' => null,
+                    'total_water_processed' => 0,
+                    'average_water_per_cycle' => 0,
+                    'total_water_liters' => 0,
                 ],
                 'meta' => [
                     'device_id' => $deviceId,
@@ -822,6 +825,13 @@ class ReportsController extends Controller
             2
         );
 
+        // Water usage analytics
+        $totalWaterProcessed = $reports->sum('water_liters');
+        $averageWaterPerCycle = $reports->count() > 0
+            ? round($totalWaterProcessed / $reports->count(), 2)
+            : 0;
+        $latestTotalWater = $reports->sortByDesc('start_time')->first()?->total_water_liters ?? 0;
+
         return response()->json([
             'status' => 'success',
             'data' => [
@@ -833,6 +843,9 @@ class ReportsController extends Controller
                 'average_improvements' => $averageImprovements,
                 'failure_analysis' => $failureAnalysis,
                 'performance_score' => $performanceScore,
+                'total_water_processed' => $totalWaterProcessed,
+                'average_water_per_cycle' => $averageWaterPerCycle,
+                'total_water_liters' => $latestTotalWater,
             ],
             'meta' => [
                 'device_id' => $deviceId,
@@ -894,6 +907,8 @@ class ReportsController extends Controller
                     'success_rate_trend' => [],
                     'efficiency_score_trend' => 'stable',
                     'maintenance_recommendation' => null,
+                    'total_water_processed' => 0,
+                    'average_water_per_day' => 0,
                 ],
                 'meta' => [
                     'device_id' => $deviceId,
@@ -939,6 +954,7 @@ class ReportsController extends Controller
             $cycleTrends[] = [
                 'date' => $date,
                 'cycle_count' => $dayReports->count(),
+                'water_liters' => $dayReports->sum('water_liters'),
             ];
 
             $successRate = $dayReports->where('final_status', 'success')->count() / $dayReports->count() * 100;
@@ -980,6 +996,10 @@ class ReportsController extends Controller
             $maintenanceRecommendation = 'Low cycle frequency detected. Verify system is operating as expected.';
         }
 
+        // Water usage analytics
+        $totalWaterProcessed = $reports->sum('water_liters');
+        $averageWaterPerDay = $days > 0 ? round($totalWaterProcessed / $days, 2) : 0;
+
         return response()->json([
             'status' => 'success',
             'data' => [
@@ -990,6 +1010,8 @@ class ReportsController extends Controller
                 'efficiency_score_trend' => $efficiencyTrend,
                 'recent_success_rate' => $recentSuccessRate,
                 'maintenance_recommendation' => $maintenanceRecommendation,
+                'total_water_processed' => $totalWaterProcessed,
+                'average_water_per_day' => $averageWaterPerDay,
             ],
             'meta' => [
                 'device_id' => $deviceId,

--- a/app/Http/Requests/Reports/TreatmentReportRequest.php
+++ b/app/Http/Requests/Reports/TreatmentReportRequest.php
@@ -20,7 +20,7 @@ class TreatmentReportRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'device_id' => ['required', 'exists:devices,id'],
+            'device_id' => ['nullable', 'exists:devices,id'],
             'date_from' => ['nullable', 'date', 'before_or_equal:date_to'],
             'date_to' => ['nullable', 'date', 'after_or_equal:date_from'],
             'days' => ['nullable', 'integer', 'min:1', 'max:90'],

--- a/app/Jobs/CheckDeviceOfflineJob.php
+++ b/app/Jobs/CheckDeviceOfflineJob.php
@@ -12,7 +12,8 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
 /**
- * Dispatched 90 seconds after a heartbeat is received.
+ * Dispatched 60 seconds after a heartbeat is received.
+ * IoT publishes heartbeat every 45 seconds, so 60s timeout gives 15s buffer.
  * If no newer heartbeat arrived, marks the device offline and pauses treatment if needed (valve 1 open, dirty water > 6%).
  */
 class CheckDeviceOfflineJob implements ShouldQueue
@@ -31,11 +32,11 @@ class CheckDeviceOfflineJob implements ShouldQueue
         }
 
         $device->refresh();
-        $threshold = now()->subSeconds(90);
+        $threshold = now()->subSeconds(60);
         $lastHeartbeat = $device->last_heartbeat_at;
 
         if ($lastHeartbeat !== null && $lastHeartbeat->gte($threshold)) {
-            // A heartbeat arrived in the last 90 seconds – still online, do nothing
+            // A heartbeat arrived in the last 60 seconds – still online, do nothing
             return;
         }
 
@@ -43,7 +44,7 @@ class CheckDeviceOfflineJob implements ShouldQueue
             return;
         }
 
-        Log::info('CheckDeviceOfflineJob: Marking device offline (no heartbeat within 90s)', [
+        Log::info('CheckDeviceOfflineJob: Marking device offline (no heartbeat within 60s)', [
             'serial' => $this->deviceSerial,
             'last_heartbeat_at' => $lastHeartbeat?->toDateTimeString(),
         ]);

--- a/app/Services/FiltrationService.php
+++ b/app/Services/FiltrationService.php
@@ -94,6 +94,8 @@ class FiltrationService
     /**
      * Handle valve 1 state changes
      * State: 1=open, 0=closed
+     * Stage 1 (MFC) completes when valve opens (state=1)
+     * Stages 2-4 start when valve opens (state=1)
      */
     public function handleValve1State(string $deviceSerial, int $stateValue): void
     {
@@ -121,18 +123,18 @@ class FiltrationService
             // Update valve state
             $filtrationProcess->update(['valve_1_state' => (bool)$stateValue]);
 
-            // If valve closed (0) on a paused process (resume after machine came back online), just set active
-            if ($stateValue === 0 && $filtrationProcess->status === 'paused') {
+            // If valve opened (1) on a paused process (resume after machine came back online), just set active
+            if ($stateValue === 1 && $filtrationProcess->status === 'paused') {
                 $filtrationProcess->update(['status' => 'active']);
-                Log::info('FiltrationService: Paused process resumed – valve 1 closed, set active', [
+                Log::info('FiltrationService: Paused process resumed – valve 1 opened, set active', [
                     'serial' => $deviceSerial,
                     'filtration_process_id' => $filtrationProcess->id,
                 ]);
                 return;
             }
 
-            // If valve closed (0) and Stage 1 is processing, complete Stage 1 and start Stage 2-4 cycle
-            if ($stateValue === 0) {
+            // If valve opened (1) and Stage 1 is processing, complete Stage 1 and start Stage 2-4 cycle
+            if ($stateValue === 1) {
                 $stage1 = TreatmentStage::where('treatment_id', $filtrationProcess->treatment_report_id)
                     ->where('stage_order', 1)
                     ->where('status', 'processing')
@@ -174,7 +176,7 @@ class FiltrationService
                         'success'
                     );
                 } else {
-                    Log::warning('FiltrationService: Valve 1 closed but Stage 1 not in processing – skipping completion', [
+                    Log::warning('FiltrationService: Valve 1 opened but Stage 1 not in processing – skipping completion', [
                         'serial' => $deviceSerial,
                         'treatment_report_id' => $filtrationProcess->treatment_report_id,
                     ]);
@@ -194,6 +196,8 @@ class FiltrationService
     /**
      * Handle valve 1 acknowledgment (when IoT sends ack=1 but no state message).
      * Treats ack as "command executed" and toggles valve state, then publishes state so frontend stays in sync.
+     * Stage 1 (MFC) completes when valve opens (state=1)
+     * Stages 2-4 start when valve opens (state=1)
      */
     public function handleValve1Ack(string $deviceSerial): void
     {
@@ -218,17 +222,17 @@ class FiltrationService
             // Ack=1 means command executed; new state is the opposite of current (OPEN/CLOSE toggled)
             $newState = $filtrationProcess->valve_1_state ? 0 : 1;
 
-            // If we would toggle to "open" but Stage 1 was already completed (stages_2_4 started), this is a late ack – keep valve closed
-            if ($newState === 1 && $filtrationProcess->stages_2_4_started_at !== null) {
-                $newState = 0;
+            // If we would toggle to "close" but Stage 1 was already completed (stages_2_4 started), this is a late ack – keep valve open
+            if ($newState === 0 && $filtrationProcess->stages_2_4_started_at !== null) {
+                $newState = 1;
             }
             $filtrationProcess->update(['valve_1_state' => (bool)$newState]);
 
-            // If valve closed (0) on a paused process, set back to active (resume after machine came back online)
-            if ($newState === 0 && $filtrationProcess->status === 'paused') {
+            // If valve opened (1) on a paused process, set back to active (resume after machine came back online)
+            if ($newState === 1 && $filtrationProcess->status === 'paused') {
                 $filtrationProcess->update(['status' => 'active']);
                 $this->publishValve1State($deviceSerial, $newState);
-                Log::info('FiltrationService: Paused process resumed (from valve ack) – valve 1 closed, set active', [
+                Log::info('FiltrationService: Paused process resumed (from valve ack) – valve 1 opened, set active', [
                     'serial' => $deviceSerial,
                     'filtration_process_id' => $filtrationProcess->id,
                 ]);
@@ -238,8 +242,8 @@ class FiltrationService
             // Publish valve 1 state so frontend can update UI
             $this->publishValve1State($deviceSerial, $newState);
 
-            // If valve closed (0) and Stage 1 is processing, complete Stage 1 and start Stage 2-4 cycle
-            if ($newState === 0) {
+            // If valve opened (1) and Stage 1 is processing, complete Stage 1 and start Stage 2-4 cycle
+            if ($newState === 1) {
                 $stage1 = TreatmentStage::where('treatment_id', $filtrationProcess->treatment_report_id)
                     ->where('stage_order', 1)
                     ->where('status', 'processing')
@@ -271,7 +275,7 @@ class FiltrationService
                         'success'
                     );
                 } else {
-                    Log::warning('FiltrationService: Valve 1 ack (closed) but Stage 1 not in processing – skipping completion', [
+                    Log::warning('FiltrationService: Valve 1 ack (opened) but Stage 1 not in processing – skipping completion', [
                         'serial' => $deviceSerial,
                         'treatment_report_id' => $filtrationProcess->treatment_report_id,
                     ]);
@@ -665,6 +669,7 @@ class FiltrationService
     /**
      * Check automatic valve 1 conditions based on sensor data
      * Called from MQTTSensorDataHandlerService after saving sensor readings
+     * OPEN condition triggers Stage 1 completion and Stages 2-4 start
      */
     public function checkAutoValveConditions(int $deviceId, string $waterType, array $sensorData): void
     {
@@ -691,12 +696,13 @@ class FiltrationService
             }
 
             // OPEN condition: water_level >= 100 AND dirty_water.electric_current < 10 AND stage 1 started more than 1 day ago AND valve not open
+            // When valve opens, Stage 1 completes and Stages 2-4 begin
             if (!$filtrationProcess->valve_1_state && $waterLevel >= 100) {
                 $currentOk = $electricCurrent !== null && (float)$electricCurrent < 10;
                 $stage1OldEnough = $filtrationProcess->stage_1_started_at &&
                     $filtrationProcess->stage_1_started_at->diffInHours(now()) >= 24;
                 if ($currentOk && $stage1OldEnough) {
-                    Log::info('FiltrationService: Auto-opening valve 1', [
+                    Log::info('FiltrationService: Auto-opening valve 1 (Stage 1 will complete and Stages 2-4 will start)', [
                         'device_id' => $deviceId,
                         'water_level' => $waterLevel,
                         'electric_current' => $electricCurrent,
@@ -707,7 +713,7 @@ class FiltrationService
                 }
             }
 
-            // CLOSE condition: water_level < 6 only (valve is open and tank drained)
+            // CLOSE condition: water_level < 6 only (valve is open and tank drained during Stage 1 MFC process)
             if ($filtrationProcess->valve_1_state && $waterLevel < 6) {
                 Log::info('FiltrationService: Auto-closing valve 1', [
                     'device_id' => $deviceId,
@@ -780,7 +786,8 @@ class FiltrationService
 
     /**
      * Called when device is detected offline (no heartbeat within 90s).
-     * Pauses treatment only if: valve 1 is open AND dirty_water water level > 6%.
+     * Pauses treatment only if: Stages 2-4 have started AND valve 1 is open AND dirty_water water level > 6%.
+     * (Valve 1 opens to complete Stage 1 and start Stages 2-4, so if device goes offline with valve open during stages 2-4, we pause)
      */
     public function onDeviceOffline(Device $device): void
     {
@@ -827,7 +834,7 @@ class FiltrationService
 
     /**
      * Called when heartbeat received (device online).
-     * If there is a paused process with valve_1_state true (water was in anode), re-open valve 1.
+     * If there is a paused process with valve_1_state true (water was in anode during Stages 2-4), re-open valve 1.
      */
     public function onDeviceOnline(string $deviceSerial): void
     {


### PR DESCRIPTION
This pull request introduces several improvements to device-specific filtering, MQTT topic handling, and reporting for water treatment devices. The most significant changes include stricter device association checks in MQTT listeners, enhanced handling of heartbeat and filtration topics, and more robust analytics and validation in reporting endpoints. These updates ensure that data is processed only for the intended device, improve offline/online status management, and provide more accurate and user-friendly reporting.

**Device-specific filtering and validation:**

* Added the `isListenerDevice` method in `MqttListen.php` to ensure that MQTT messages are only processed for the device specified by the `device-id` option. All relevant topic handlers now check device association before processing. (F41aa4daL423)
* Updated the command signature and descriptions for `MqttListen` and `CheckDeviceHeartbeat` to clarify device filtering and heartbeat intervals. [[1]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65L16-R17) [[2]](diffhunk://#diff-fd51a7b503c97987130c029d093612e44e32c27bbca83aa27639cd1e84615445L12-R13)

**MQTT topic handling improvements:**

* Modified the heartbeat handler to process payload values (`1` for online, `0` for offline), update device status accordingly, and schedule offline checks after 60 seconds instead of 90. Heartbeats and AI classification topics are now only processed for the correct device. [[1]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R194-R244) [[2]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65L162-R162)
* All filtration-related MQTT topic handlers now ignore messages not associated with the monitored device, preventing cross-device data leakage. [[1]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R269-R271) [[2]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R284-R286) [[3]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R299-R301) [[4]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R310-R312) [[5]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R325-R327) [[6]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R336-R338) [[7]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R351-R353) [[8]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R366-R368) [[9]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R377-R379) [[10]](diffhunk://#diff-e5dc212f7c13dfb1a8c9289bc9a406723c82d5fcf1a1204847b862367adbfc65R392-R394)

**Reporting and analytics enhancements:**

* In `ReportsController`, both `treatmentPerformance` and `treatmentEfficiency` endpoints now validate that the requested device belongs to the authenticated user. If no device is provided, the first available device is used; if the user has no devices, a friendly "No Data Available" message is returned. [[1]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R688-R716) [[2]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R864-R893)
* Both endpoints now include water usage analytics in their responses, such as `total_water_processed`, `average_water_per_cycle` or `average_water_per_day`, and `total_water_liters`. These metrics are included even when there is no data. [[1]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R725-R735) [[2]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R828-R834) [[3]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R846-R848) [[4]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R903-R911) [[5]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R957) [[6]](diffhunk://#diff-85a2b6549a038e42b0b3d202310f83f880bf25514390348824ece420c8118877R999-R1002)

These changes collectively improve security, accuracy, and user experience when monitoring and reporting on water treatment devices.