### PR TITLE
Develop

### DIFF
--- a/app/Jobs/CloseValve1Job.php
+++ b/app/Jobs/CloseValve1Job.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Device;
+use App\Models\FiltrationProcess;
+use App\Services\FiltrationService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class CloseValve1Job implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $deviceId;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(int $deviceId)
+    {
+        $this->deviceId = $deviceId;
+    }
+
+    /**
+     * Execute the job - automatically close valve 1 after 24 minutes if still open.
+     */
+    public function handle(FiltrationService $filtrationService): void
+    {
+        Log::info('CloseValve1Job: Executing auto-close for valve 1', [
+            'device_id' => $this->deviceId
+        ]);
+
+        try {
+            $device = Device::find($this->deviceId);
+            
+            if (!$device) {
+                Log::warning('CloseValve1Job: Device not found', [
+                    'device_id' => $this->deviceId
+                ]);
+                return;
+            }
+
+            $filtrationProcess = FiltrationProcess::where('device_id', $device->id)
+                ->whereIn('status', ['active', 'paused'])
+                ->first();
+            
+            if (!$filtrationProcess) {
+                Log::info('CloseValve1Job: No active or paused filtration process found', [
+                    'device_id' => $this->deviceId
+                ]);
+                return;
+            }
+
+            // Only close if valve 1 is still open
+            if (!$filtrationProcess->valve_1_state) {
+                Log::info('CloseValve1Job: Valve 1 already closed, skipping', [
+                    'device_id' => $this->deviceId
+                ]);
+                return;
+            }
+
+            // Send CLOSE command to valve 1
+            $filtrationService->publishCommand(
+                "mfc/{$device->serial_number}/valve/1",
+                'CLOSE'
+            );
+
+            Log::info('CloseValve1Job: Auto-close command sent for valve 1', [
+                'device_id' => $this->deviceId,
+                'device_serial' => $device->serial_number
+            ]);
+
+        } catch (\Exception $e) {
+            Log::error('CloseValve1Job: Failed to auto-close valve 1', [
+                'device_id' => $this->deviceId,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
+            throw $e;
+        }
+    }
+}

--- a/app/Services/FiltrationService.php
+++ b/app/Services/FiltrationService.php
@@ -96,6 +96,7 @@ class FiltrationService
      * State: 1=open, 0=closed
      * Stage 1 (MFC) completes when valve opens (state=1)
      * Stages 2-4 start when valve opens (state=1)
+     * When valve opens, schedule auto-close after 24 minutes
      */
     public function handleValve1State(string $deviceSerial, int $stateValue): void
     {
@@ -131,6 +132,21 @@ class FiltrationService
                     'filtration_process_id' => $filtrationProcess->id,
                 ]);
                 return;
+            }
+
+            // If valve opened (1), schedule auto-close after 24 minutes
+            if ($stateValue === 1) {
+                $delaySeconds = 24 * 60; // 24 minutes in seconds
+                
+                \App\Jobs\CloseValve1Job::dispatch($device->id)
+                    ->delay(now()->addSeconds($delaySeconds));
+                
+                Log::info('FiltrationService: Scheduled auto-close for valve 1', [
+                    'serial' => $deviceSerial,
+                    'device_id' => $device->id,
+                    'delay_seconds' => $delaySeconds,
+                    'close_at' => now()->addSeconds($delaySeconds)->toDateTimeString()
+                ]);
             }
 
             // If valve opened (1) and Stage 1 is processing, complete Stage 1 and start Stage 2-4 cycle
@@ -198,6 +214,7 @@ class FiltrationService
      * Treats ack as "command executed" and toggles valve state, then publishes state so frontend stays in sync.
      * Stage 1 (MFC) completes when valve opens (state=1)
      * Stages 2-4 start when valve opens (state=1)
+     * When valve opens, schedule auto-close after 24 minutes
      */
     public function handleValve1Ack(string $deviceSerial): void
     {
@@ -222,10 +239,6 @@ class FiltrationService
             // Ack=1 means command executed; new state is the opposite of current (OPEN/CLOSE toggled)
             $newState = $filtrationProcess->valve_1_state ? 0 : 1;
 
-            // If we would toggle to "close" but Stage 1 was already completed (stages_2_4 started), this is a late ack – keep valve open
-            if ($newState === 0 && $filtrationProcess->stages_2_4_started_at !== null) {
-                $newState = 1;
-            }
             $filtrationProcess->update(['valve_1_state' => (bool)$newState]);
 
             // If valve opened (1) on a paused process, set back to active (resume after machine came back online)
@@ -241,6 +254,21 @@ class FiltrationService
 
             // Publish valve 1 state so frontend can update UI
             $this->publishValve1State($deviceSerial, $newState);
+
+            // If valve opened (1), schedule auto-close after 24 minutes
+            if ($newState === 1) {
+                $delaySeconds = 24 * 60; // 24 minutes in seconds
+                
+                \App\Jobs\CloseValve1Job::dispatch($device->id)
+                    ->delay(now()->addSeconds($delaySeconds));
+                
+                Log::info('FiltrationService: Scheduled auto-close for valve 1', [
+                    'serial' => $deviceSerial,
+                    'device_id' => $device->id,
+                    'delay_seconds' => $delaySeconds,
+                    'close_at' => now()->addSeconds($delaySeconds)->toDateTimeString()
+                ]);
+            }
 
             // If valve opened (1) and Stage 1 is processing, complete Stage 1 and start Stage 2-4 cycle
             if ($newState === 1) {
@@ -698,7 +726,7 @@ class FiltrationService
             // OPEN condition: water_level >= 100 AND dirty_water.electric_current < 10 AND stage 1 started more than 1 day ago AND valve not open
             // When valve opens, Stage 1 completes and Stages 2-4 begin
             if (!$filtrationProcess->valve_1_state && $waterLevel >= 100) {
-                $currentOk = $electricCurrent !== null && (float)$electricCurrent < 10;
+                $currentOk = $electricCurrent !== null && (float)$electricCurrent < 50;
                 $stage1OldEnough = $filtrationProcess->stage_1_started_at &&
                     $filtrationProcess->stage_1_started_at->diffInHours(now()) >= 24;
                 if ($currentOk && $stage1OldEnough) {


### PR DESCRIPTION
This pull request introduces an automatic safety mechanism to ensure valve 1 is closed after being open for 24 minutes, reducing the risk of it being left open unintentionally. It does this by scheduling a delayed job whenever valve 1 is opened, both when its state is directly set and when an ACK is received. Additionally, it slightly relaxes the electric current threshold for opening valve 1.

**Automatic valve 1 auto-close feature:**

* Adds a new queued job, `CloseValve1Job`, which checks if valve 1 is still open after 24 minutes and closes it if necessary. This job includes logging and error handling.
* Updates `FiltrationService` to schedule the `CloseValve1Job` with a 24-minute delay whenever valve 1 is opened, both in `handleValve1State` and `handleValve1Ack`, with appropriate logging for traceability. [[1]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfR137-R151) [[2]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfR258-R272)

**Threshold adjustment:**

* Increases the electric current threshold for opening valve 1 from `< 10` to `< 50`, making it easier for the system to trigger valve opening under certain conditions.

**Code and logic cleanup:**

* Removes logic in `handleValve1Ack` that previously prevented closing valve 1 if certain stages had already started, simplifying state transitions.

**Documentation and comments:**

* Updates and adds comments in `FiltrationService` to document the new auto-close scheduling behavior. [[1]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfR99) [[2]](diffhunk://#diff-feec9a849205a2fa2b3d33ddff09bb9eecb547104bb50289c4605924ce191dcfR217)